### PR TITLE
destroy method stops any stray animation

### DIFF
--- a/src/Impetus.js
+++ b/src/Impetus.js
@@ -74,6 +74,7 @@ export default class Impetus {
          * this will remove the previous event listeners
          */
         this.destroy = function() {
+            decelerating = false;// stop stray animations
             sourceEl.removeEventListener('touchstart', onDown);
             sourceEl.removeEventListener('mousedown', onDown);
             // however it won't "destroy" a reference


### PR DESCRIPTION
destroy method stops any stray animation loop that can remain on element removal in some situations.