### PR TITLE
Fix multi-touch (additional touches causing jumps)

### DIFF
--- a/src/Impetus.js
+++ b/src/Impetus.js
@@ -159,7 +159,7 @@ export default class Impetus {
          */
         function normalizeEvent(ev) {
             if (ev.type === 'touchmove' || ev.type === 'touchstart' || ev.type === 'touchend') {
-                var touch = ev.targetTouches[0] || ev.changedTouches[0];
+                var touch = ev.changedTouches[0];
                 return {
                     x: touch.clientX,
                     y: touch.clientY,


### PR DESCRIPTION
This is the same fix as #33, but this new pull request contains only the relevant changes (I forgot to create a branch before creating my original pull request).

---

Considering `ev.targetTouches[0]` before `ev.changedTouches[0]` in `normalizeEvent()` meant that having multiple target touches where the first touch wasn't the same as the one stored by Impetus as the "pointer" would prevent the condition in `onUp()` from triggering, leaving the internal state in "started" mode (`stopTracking()` not called) event after all touches had been released. In essence, `onUp()` was called twice (once for each released touch) but in both cases it tested `ev.targetTouches[0]` which didn't match the stored "pointer" touch, which was at index 1, causing `stopTracking()` never to be called.

Unless I'm missing something, as the various event handlers already filter out "unwanted" touches (by storing the first touch's id and checking against that), event normalization can safely consider changed touches only (the touch concerned by the current event), which fixes at least this edge case and makes tracking more reliable when multiple touches are present.

[Before (video)](http://irradiated.net/files/IMG_3021.MOV)
[After (video)](http://irradiated.net/files/IMG_3022.MOV)